### PR TITLE
Align Tepla example JSON files with v1 schema format

### DIFF
--- a/schema/examples/GeneralSection_json_Tepla.json
+++ b/schema/examples/GeneralSection_json_Tepla.json
@@ -1,225 +1,28 @@
 {
-    "$schema":"http://json-schema.org/draft-04/schema",
-    "title": "json schema for the fa4.0 standardized header",
-    "type": "object",
-    "description": "this schema defines the standard json header used for the meta data collection within the fa4.0 project. it defines each section as well es the properties of the general and method specific section where metadata of a measurement should be mapped to. the general section is thereby identical for all tools.",
-    "generalsection": {
-        "description": "the general section incorporates all necessary metadata from the general section.",
-        "title": "generalsection header",
-        "type": "object",
-        "process": "coordinate_transformation.py",
-        "properties": {
-            "file path": {
-                "title": "the path to the generated file, linked to the json file.",
-                "type": "string",
-                "example": "w:\\_fa4\\marko\\zeiss meta\\test"
-            },
-            "file name": {
-                "title": "the name of the generated file, linked to the json file.",
-                "type": "string"
-            },
-            "file format": {
-                "title": "indicates the file format.",
-                "type": "string",
-                "example": ".tiff"
-            },
-            "file size": {
-                "title": "the file size in [bytes]",
-                "type": "integer"
-            },
-            "logfile path": {
-                "title": "the path to the created log file of the tool. is left ommitted if there is no existing logfile.",
-                "type": "string"
-            },
-            "previous header file": {
-                "type": "string",
-                "title": "the name of the previous header file in the ifact workflow history."
-            },
-            "header type": {
-                "title": "use standard for creation of header file",
-                "type": "string",
-                "example": "fa4.0 standardized header"
-            },
-            "version": {
-                "title": "the version of the standard header type.",
-                "type": "string",
-                "example": "v1.0"
-            },
-            "time stamp": {
-                "title": "the time stamp, when the file was generated in iso8601 format (yyyy-mm-dd hh:mm:ss). an add on indicates the differences to the coordinated universal time (utc), for example +01:00 for central european time (cet)",
-                "type": "string",
-                "example": "2022-10-31t16:05:25+01:00"
-            },
-            "manufacturer": {
-                "title": "the manufacturer name of the measurement tool.",
-                "type": "string",
-                "example": "zeiss microscopy"
-            },
-            "tool name": {
-                "title": "the name of the measurement tool.",
-                "type": "string",
-                "example": "sem 500-1"
-            },
-            "serial number": {
-                "title": "the value is the unique manufacturer serial number of a measurement tool.",
-                "type": "string"
-            },
-            "method": {
-                "title": "indicates the analysis method.",
-                "type": "string",
-                "example": "sem"
-            },
-            "image width": {
-                "title": "the width of the image in pixel.",
-                "type": "integer",
-                "example": "1050"
-            },
-            "image length": {
-                "title": "the length of the image in pixel.",
-                "type": "integer",
-                "example": "1050"
-            },
-            "pixel length": {
-                "title": "the length per pixel in [um].",
-                "type": "number",
-                "example": "3.307292"
-            },
-            "pixel width": {
-                "title": "the width per pixel in [um].",
-                "type": "number",
-                "example": "3.307292"
-            },
-            "bit depth": {
-                "title": "the number of bits each pixel can resolute. for example a 8-bit depth in a grayscale image, means a resolution of 256 grayscales.",
-                "type": "integer",
-                "example": "8"
-            },
-            "compressed bits/pixel": {
-                "title": "the amount of compressed bits per pixel.",
-                "type": "number"
-            },
-            "color mode": {
-                "title": "the color mode of the image",
-                "type": "string",
-                "enum": [
-                    "grayscale",
-                    "rgb"
-                ]
-            },
-            "customer": {
-                "title": "the name of the respective company which performed the measurement.",
-                "type": "string",
-                "example": "infineon"
-            },
-            "coordinates sub section": {
-                "type":"object",
-                "properties": {
-                    "stage coordinate system orientation": {
-                        "title": "indicates whether the tool's cartesian coordinate system is right or left handed.",
-                        "type": "string",
-                        "enum": [
-                            "right handed",
-                            "left handed"
-                        ],
-                        "example": "right handed"
-                    },
-                    "global or local frame movement": {
-                        "title": "this value indicates whether chained movements of the tool's stage are defined around a global fixed frame or around its local frame. the boolean 1 states the stage is moving around a global frame and 0 around its local frame respectively.",
-                        "type": "boolean",
-                        "example": "1"
-                    },
-                    "relative orientation to screens coordinate frame": {
-                        "title": "this array describes the relative offset orientation of the tool's global frame to the screens coordinate frame. the first entry denotes the angle around the x-axis, the second around the y-axis and the third around the z-axis in degrees. the angles are relative to the tools global frame.",
-                        "type": "array",						
-						"minItems": 3,
-						"maxItems": 3,
-                        "items": {
-                            "type": "number",
-                            "default": 100
-                        }
-                    },
-                    "stage coordinates X Y Z": {
-                        "title": "This array describes the stage coordinates",
-                        "type": "array",
-						"minItems": 3,
-						"maxItems": 3,
-                        "items": {
-                            "type": "number",
-                            "default": 100
-                        }
-                    },
-                    "stage rotation Rx": {
-                        "title": "rx is the vertical angle which describes the rotation of the tool's stage around a horizontal axis parallel to the x-axis of either the tool's global or local frame in degrees",
-                        "type": "number",
-                        "example": "20.4",
-                        "minimum": -180,
-                        "maximum": 180
-                    },
-                    "stage rotation Ry": {
-                        "title": "ry is the vertical angle which describes the rotation of the tool's stage around a horizontal axis parallel to the y-axis of either the tool's global or local frame in degrees",
-                        "type": "number",
-                        "example": "20.4",
-                        "minimum": -180,
-                        "maximum": 180
-                    },
-                    "stage rotation Rz": {
-                        "title": "rz is the horizontal angle which describes the rotation of the tool's stage around a vertical axis parallel to the z-axis of either the tool's global or local frame in degrees",
-                        "type": "number",
-                        "example": "22.5",
-                        "minimum": -180,
-                        "maximum": 180
-                    }
-                }
-            },
-            "alignment Marks Sub section": {
-                "type":"object",
-                "properties": {
-                    "position of the Fiducials": {
-						"type":"object",
-						"properties": {
-                            "mark1": {
-                                "title": "This array describes the Mark 1",
-                                "type": "array",
-                                "minItems": 3,
-                                "maxItems": 3,
-                                "items": {
-                                    "type": "number",
-                                    "default": 100
-                                }
-                            },
-                            "mark2":{
-                                "title": "This array describes the Mark 2",
-                                "type": "array",
-                                "minItems": 3,
-                                "maxItems": 3,
-                                "items": {
-                                    "type": "number",
-                                    "default": 100
-                                }
-                            },
-                            "mark3":{
-                                "title": "This array describes the Mark 3",
-                                "type": "array",
-                                "minItems": 3,
-                                "maxItems": 3,
-                                "items": {
-                                    "type": "number",
-                                    "default": 100
-                                }
-                            }
-                        }
-                    },
-                    "type of Fiducials":{
-                        "title": "the version of the standard header type.",
-                        "type": "string",
-                        "example": "v1.0"
-                    },
-                    "fiducial Size": {
-                        "title": "the version of the standard header type.",
-                        "type": "string"
-                    }
-                }
-            }
-        }
-    }
+  "General Section": {
+    "File Path": "c:\\iFAct_exchange",
+    "File Name": "FA4_0_white_bumps_test_session2_channel0_Scan9 XGate1_2.tiff",
+    "File Format": ".tiff",
+    "File Size": {
+      "Value": 1918676,
+      "Unit": "bytes"
+    },
+    "Header Type": "FA4.0 standardized header",
+    "Version": "v1.0",
+    "Time Stamp": "2025-12-09T14:30:00+01:00",
+    "Manufacturer": "PVA Tepla Analytical Systems GmbH",
+    "Tool Name": "Tepla Analytical System",
+    "Serial Number": "TEPLA-0001",
+    "Method": "SEM",
+    "Image Width": {
+      "Value": 1468,
+      "Unit": "pixel"
+    },
+    "Image Height": {
+      "Value": 1468,
+      "Unit": "pixel"
+    },
+    "Bit Depth": 8,
+    "Color Mode": "grayscale"
+  }
 }

--- a/schema/examples/MethodSection_json_Tepla.json
+++ b/schema/examples/MethodSection_json_Tepla.json
@@ -1,94 +1,20 @@
 {
-    "methodspecific": {
-        "title": "method specific",
-        "description": "the method specific section incorporates the all neccessary metadata for each measurement methods.",
-        "type": "object",
-        "properties": {
-            "newSubfileType": {
-                "description": "The new subfile type",
-                "type": "string",
-                "example": "2"
-            },
-            "imageWidth": {
-                "description": "The image width",
-                "type": "integer",
-                "example": "0"
-            },
-            "imageLength": {
-                "description": "The image length",
-                "type": "integer",
-                "example": "0"
-            },
-            "bitsPerSample": {
-                "description": "Bits per Sample",
-                "type": "integer",
-                "example": "7"
-            },
-            "compression": {
-                "description": "The compression ratio",
-                "type": "integer",
-                "example": "3"
-            },
-            "photometricInterpretation": {
-                "description": "the type of PhotometricInterpretation",
-                "type": "string",
-                "example": "Palette"
-            },
-            "stripOffsets": {
-                "description": "StripOffsets",
-                "type": "integer",
-                "example": "1918676"
-            },
-            "orientation": {
-                "description": "Orientation",
-                "type": "string",
-                "example": "TopLeft"
-            },
-            "samplesPerPixel": {
-                "description": "SamplesPerPixel",
-                "type": "integer",
-                "example": "1"
-            },
-            "rowsPerStrip": {
-                "description": "RowsPerStrip",
-                "type": "integer",
-                "example": "1307"
-            },
-            "stripByteCounts": {
-                "description": "StripByteCounts",
-                "type": "integer",
-                "example": "1918676"
-            },
-            "xResolution": {
-                "description": "XResolution",
-                "type": "numerical",
-                "example": "96.0"
-            },
-            "yResolution": {
-                "description": "YResolution",
-                "type": "numerical",
-                "example": "96.0"
-            },
-            "resolutionUnit": {
-                "description": "Resolution Unit",
-                "type": "string",
-                "example": "Inch"
-            },
-            "colorMap": {
-                "description": "ColorMap",
-                "type": "string",
-                "example": "RGB"
-            },
-            "sampleFormat": {
-                "description": "SampleFormat",
-                "type": "string",
-                "example": "tmp"
-            },
-            "cz_SEM": {
-                "description": "CZ_SEM",
-                "type": "string",
-                "example": "tmp"
-            }
-        }
+  "Method Specific": {
+    "Scanning Electron Microscopy": {
+      "Accelerating Voltage": {
+        "Value": 5.0,
+        "Unit": "kV"
+      },
+      "Working Distance": {
+        "Value": 8.5,
+        "Unit": "mm"
+      },
+      "Signal Type(s)": [
+        "SE2"
+      ],
+      "Detector(s)": [
+        "SE Detector"
+      ]
     }
+  }
 }

--- a/schema/examples/ToolSection_json_Tepla.json
+++ b/schema/examples/ToolSection_json_Tepla.json
@@ -1,176 +1,63 @@
 {
-    "toolspecific": {
-        "title": "Tool specific",
-        "description": "the tool specific section contains the metadata which are specific for a tool.",
-        "type": "object",
-        "properties": {
-            "method": {
-                "description": "method",
-                "type": "string",
-                "example": "PeakBipolar"
-            },
-            "fileHeaderLength": {
-                "description": "fileHeaderLength",
-                "type": "integer",
-                "example": "50"
-            },
-            "date": {
-                "description": "Date",
-                "type": "date",
-                "example": "18.04.2023 00:00:00"
-            },
-            "filelocation": {
-                "description": "filelocation",
-                "type": "string",
-                "example": "c:\\iFAct_exchange\\FA4_0_white_bumps_test_session2_channel0_Scan9 XGate1_2.tiff"
-            },
-            "multiPurposeFileLocation": {
-                "description": "MultiPurposeFileLocation",
-                "type": "string",
-                "example": "c:\\iFAct_exchange\\FA4_0_white_bumps_test_session2_channel0_Scan9 XGate1_2.tiff"
-            },
-            "tool": {
-                "type": "object",
-                "properties": {
-                    "manufacturer": {
-                        "description": "Manufacturer",
-                        "type": "string",
-                        "example": "PVA Tepla Analytical Systems GmbH"
-                    },
-                    "version": {
-                        "description": "Version",
-                        "type": "string",
-                        "example": "8.23.2.3"
-                    },
-                    "fileVSN": {
-                        "description": "fileVSN",
-                        "type": "string",
-                        "example": "8.23.2.3"
-                    }
-                }
-            },
-            "scan": {
-                "type": "object",
-                "properties": {
-                    "sequence": {
-                        "description": "sequence",
-                        "type": "string"
-                    },
-                    "mode": {
-                        "description": "mode",
-                        "type": "string",
-                        "example": ""
-                    },
-                    "width": {
-                        "description": "width",
-                        "type": "numerical",
-                        "example": "14678,8507109005"
-                    },
-                    "height": {
-                        "description": "height",
-                        "type": "numerical",
-                        "example": "14678,8507109005"
-                    },
-                    "unit": {
-                        "description": "Unit",
-                        "type": "string",
-                        "example": "mm"
-                    },
-                    "x_NbrOfPixel": {
-                        "description": "x_NbrOfPixel",
-                        "type": "integer",
-                        "example": "1468"
-                    },
-                    "y_NbrOfPixel": {
-                        "description": "y_NbrOfPixel",
-                        "type": "integer",
-                        "example": "1468"
-                    },
-                    "yLinesPerScan": {
-                        "description": "yLinesPerScan",
-                        "type": "integer",
-                        "example": "1307"
-                    },
-                    "x_CTR": {
-                        "description": "x_CTR",
-                        "type": "numerical",
-                        "example": "163653,684199052"
-                    },
-                    "y_CTR": {
-                        "description": "y_CTR",
-                        "type": "numerical",
-                        "example": "163653,684199052"
-                    },
-                    "z_CTR": {
-                        "description": "z_CTR",
-                        "type": "numerical",
-                        "example": "163653,684199052"
-                    },
-                    "name": {
-                        "description": "name",
-                        "type": "string",
-                        "example": "Scan9 XGate1_2 Channel0"
-                    }
-                }
-            },
-            "adc": {
-                "type": "object",
-                "properties": {
-                    "sampleOffset": {
-                        "description": "sampleOffset",
-                        "type": "integer"
-                    },
-                    "sampleRate": {
-                        "description": "sampleRate",
-                        "type": "integer"
-                    },
-                    "sampleRateUnit": {
-                        "description": "sampleRateUnit",
-                        "type": "string"
-                    },
-                    "inputRange": {
-                        "description": "inputRange",
-                        "type": "numerical"
-                    },
-                    "nbrOfSamplesperSignal": {
-                        "description": "nbrOfSamplesperSignal",
-                        "type": "integer"
-                    },
-                    "sampleBits": {
-                        "description": "sampleBits",
-                        "type": "integer"
-                    },
-                    "t_Sample_Start": {
-                        "description": "t_Sample_Start",
-                        "type": "integer"
-                    },
-                    "t_Sample_End": {
-                        "description": "t_Sample_End",
-                        "type": "integer"
-                    },
-                    "dataformat": {
-                        "description": "dataformat",
-                        "type": "string"
-                    }
-                }
-            },
-            "pulser": {
-                "type": "object",
-                "properties": {
-                    "gain": {
-                        "description": "gain",
-                        "type": "string"
-                    },
-                    "name": {
-                        "description": "name",
-                        "type": "string"
-                    },
-                    "preamp_name": {
-                        "description": "name",
-                        "type": "string"
-                    }
-                }
-            }
-        }
+  "Tool Specific": {
+    "PVA Tepla Analytical Systems GmbH": {
+      "Method": "PeakBipolar",
+      "File Header Length": 50,
+      "Date": "2023-04-18T00:00:00+00:00",
+      "File Location": "c:\\iFAct_exchange\\FA4_0_white_bumps_test_session2_channel0_Scan9 XGate1_2.tiff",
+      "Multi Purpose File Location": "c:\\iFAct_exchange\\FA4_0_white_bumps_test_session2_channel0_Scan9 XGate1_2.tiff",
+      "Tool": {
+        "Manufacturer": "PVA Tepla Analytical Systems GmbH",
+        "Version": "8.23.2.3",
+        "File VSN": "8.23.2.3"
+      },
+      "Scan": {
+        "Sequence": "9",
+        "Mode": "XGate",
+        "Width": {
+          "Value": 14678.8507109005,
+          "Unit": "mm"
+        },
+        "Height": {
+          "Value": 14678.8507109005,
+          "Unit": "mm"
+        },
+        "X Number Of Pixel": 1468,
+        "Y Number Of Pixel": 1468,
+        "Y Lines Per Scan": 1307,
+        "X CTR": {
+          "Value": 163653.684199052,
+          "Unit": "um"
+        },
+        "Y CTR": {
+          "Value": 163653.684199052,
+          "Unit": "um"
+        },
+        "Z CTR": {
+          "Value": 163653.684199052,
+          "Unit": "um"
+        },
+        "Name": "Scan9 XGate1_2 Channel0"
+      },
+      "ADC": {
+        "Sample Offset": 0,
+        "Sample Rate": 1000000,
+        "Sample Rate Unit": "Hz",
+        "Input Range": {
+          "Value": 1.0,
+          "Unit": "V"
+        },
+        "Number Of Samples Per Signal": 1024,
+        "Sample Bits": 12,
+        "T Sample Start": 0,
+        "T Sample End": 1023,
+        "Data Format": "int16"
+      },
+      "Pulser": {
+        "Gain": "1x",
+        "Name": "Pulser A",
+        "Preamp Name": "Preamp A"
+      }
     }
+  }
 }


### PR DESCRIPTION
  This PR fixes the Tepla files in schema/examples/ so they are valid v1 example instances (not legacy schema-definition JSON).

  ### What changed

  - Replaced legacy roots (generalsection, methodspecific, toolspecific) with v1 section names:
      - "General Section"
      - "Method Specific"
      - "Tool Specific"
  - Updated field naming and structure to v1 conventions (spaces + proper "Value"/"Unit" objects where applicable).
  - Ensured required v1 fields are present in General and SEM Method sections.
  - Kept Tepla-specific metadata under "Tool Specific" as vendor-specific content.

  ### Files updated

  - schema/examples/GeneralSection_json_Tepla.json
  - schema/examples/MethodSection_json_Tepla.json
  - schema/examples/ToolSection_json_Tepla.json

  ### Validation

  Validated each updated example against its corresponding v1 schema (General Section.json, Method Specific.json, Tool Specific.json) with jsonschema; all pass.
