### PR TITLE
Add connector schema

### DIFF
--- a/.github/skills/famdo-tiff-connector/SKILL.md
+++ b/.github/skills/famdo-tiff-connector/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: famdo-tiff-connector
+description: 'Use when creating or updating a FAMH connector or mapping JSON from a TIFF file with famdo. Extract TIFF metadata with the famdo CLI, map tags to FAMH connector fields using tag IDs, add transform invocations when needed, validate the connector JSON, and write unresolved or ambiguous tags to a sidecar .unresolved.json file instead of guessing.'
+argument-hint: 'Path to the TIFF file and desired connector or mapping file name'
+user-invocable: true
+disable-model-invocation: false
+---
+
+# Famdo TIFF Connector
+
+Create a valid connector or mapping JSON for the FA Metadata Header (FAMH) schema from TIFF metadata extracted with the `famdo` CLI.
+
+This skill is for building files such as `connectors/mappings/my-tool.json` from a real TIFF sample. It prioritizes a valid connector file over aggressive guessing. When a tag cannot be mapped confidently, keep the connector valid and write the unresolved item to a sidecar `.unresolved.json` file for user review.
+
+## When to Use
+
+- Build a new connector from a TIFF file
+- Update an existing connector after inspecting a new tool's TIFF metadata
+- Convert `famdo extract` output into `connectors/mappings/*.json`
+- Identify which TIFF tags can map directly to FAMH and which need transforms or user decisions
+
+## Preconditions
+
+- A TIFF file is available for inspection
+- `famdo` is installed or a local checkout is available
+- The target connector should follow `connectors/connector-schema.json`
+- The target mappings should default to FAMH `v1.1` unless the user explicitly asks for another version
+
+## Procedure
+
+1. Confirm the sample TIFF path and decide the connector output path.
+
+   Preferred output location: `connectors/mappings/<name>.json`
+
+   Preferred unresolved sidecar path: `connectors/mappings/<name>.unresolved.json`
+
+2. Run metadata extraction with `famdo`.
+
+   Preferred command:
+
+   ```bash
+   famdo extract <path-to-image.tif> -o <extracted-json>
+   ```
+
+   If `famdo` is not on `PATH` but a local checkout exists, use the local binary or `cargo run` from that repo.
+
+3. Inspect the extracted tag list.
+
+   Focus on:
+
+   - tag `id`
+   - tag `name`
+   - sample `value`
+   - TIFF value `type`
+
+4. Build the connector skeleton.
+
+   Start with:
+
+   ```json
+   {
+     "$schema": "./connector-schema.json",
+     "name": "<Connector Name>",
+     "version": "1.0.0",
+     "targetSchemaVersion": "1.1",
+     "mappings": []
+   }
+   ```
+
+5. Add direct mappings first.
+
+   Use direct mappings only when the TIFF value can be copied into the FAMH target without conversion.
+
+   Typical baseline mappings when present:
+
+   - `ImageWidth` (256) -> `/General Section/Image Width/Value`
+   - `ImageLength` (257) -> `/General Section/Image Height/Value`
+   - constant `"px"` -> `/General Section/Image Width/Unit`
+   - constant `"px"` -> `/General Section/Image Height/Unit`
+   - `BitsPerSample` (258) -> `/General Section/Bit Depth`
+   - `Make` (271) -> `/General Section/Manufacturer`
+   - `Model` (272) -> `/General Section/Tool Name`
+
+6. Add transform-based mappings where a transform definition already exists.
+
+   Rules:
+
+   - Use tag IDs as the canonical identifier in every `tiff-tag` source.
+   - Keep `name` for readability when available.
+   - Use the string `transform` shorthand only for simple one-input transforms.
+   - Use the object `transform` form when the transform requires extra named inputs or parameters.
+   - Bind additional transform inputs through `transform.inputs`.
+   - Bind optional transform parameters through `transform.parameters`.
+
+   Current standard examples:
+
+   - `DateTime` (306) + `datetime-tiff-to-iso8601`
+   - `XResolution` (282) + `ResolutionUnit` (296) + `resolution-to-nm-per-px`
+   - `YResolution` (283) + `ResolutionUnit` (296) + `resolution-to-nm-per-px`
+   - `PhotometricInterpretation` (262) + `photometric-to-color-mode`
+
+7. Add required companion mappings for transformed targets when needed.
+
+   Example:
+
+   - If mapping `Pixel Width/Value` or `Pixel Height/Value`, also add the corresponding `Unit` mapping, typically constant `"nm"`.
+
+8. Do not guess when the semantics are unclear.
+
+   A tag should be left out of the connector if any of the following is true:
+
+   - multiple FAMH targets are plausible
+   - the meaning depends on vendor-specific knowledge that is not present
+   - the extracted value is insufficient to derive the target confidently
+   - no transform definition exists for the required conversion
+
+9. Write unresolved items outside the connector JSON.
+
+   Keep the connector file schema-valid. Do not insert `_note`, `todo`, or comment-like properties into the JSON.
+
+    If unresolved items remain, create a sidecar JSON file next to the connector file using the same base name with the suffix `.unresolved.json`.
+
+    Recommended structure:
+
+    ```json
+    {
+       "sourceImage": "<path-to-image.tif>",
+       "connectorPath": "connectors/mappings/<name>.json",
+       "unresolved": [
+          {
+             "id": 34682,
+             "name": "Unknown(34682)",
+             "sampleValue": "...",
+             "candidateTargets": [
+                "/Tool Specific/..."
+             ],
+             "reason": "Meaning depends on vendor-specific knowledge not available from the sample."
+          }
+       ]
+    }
+    ```
+
+    Each unresolved entry should capture:
+
+   - TIFF tag ID and name
+   - sample value
+    - likely candidate FAMH target path or paths, if any
+   - reason the mapping was not added
+
+    If there are no unresolved items, do not create the sidecar file.
+
+10. Validate the connector before finishing.
+
+    At minimum:
+
+    - validate JSON syntax
+    - validate against `connectors/connector-schema.json`
+    - check that multi-input transform bindings are present when required
+    - check that transformed numeric value fields also have appropriate unit mappings when needed
+
+## Decision Rules
+
+- Default to FAMH `v1.1`
+- Prefer exact schema field names and valid JSON Pointers
+- Prefer direct mappings over transforms when no conversion is needed
+- Prefer existing transform definitions over inventing new conversions ad hoc
+- Prefer omission plus explicit review notes over speculative mappings
+- Prefer tool-agnostic standard TIFF tags first, then vendor-specific tags only when the meaning is clear
+
+## Completion Criteria
+
+The task is complete when all of the following are true:
+
+- The connector JSON is valid against `connectors/connector-schema.json`
+- Every `tiff-tag` mapping uses numeric `id`
+- Every transform invocation matches the transform definition shape as closely as the connector schema allows
+- Directly mappable baseline TIFF tags have been included when present
+- Ambiguous or unresolved tags are written to `<name>.unresolved.json` when any exist
+- The final response states what was created, what was validated, and what still needs a decision
+
+## Final Response Format
+
+Include:
+
+- the created or updated connector path
+- the unresolved sidecar path, if one was created
+- whether connector-schema validation passed
+- a short summary of direct mappings and transform-based mappings added
+- a short summary of unresolved tags needing user input
+
+## Notes
+
+- This skill is intentionally conservative. A smaller valid connector plus a clean unresolved sidecar file is better than an overfit connector with wrong mappings.
+- Keep the unresolved sidecar machine-readable. Do not mix prose paragraphs into the JSON file.

--- a/connectors/README.md
+++ b/connectors/README.md
@@ -29,7 +29,7 @@ Each entry in `mappings` has the following fields:
 | `target` | yes | JSON Pointer (RFC 6901) to the field in the FAMH output document |
 | `description` | no | Human-readable annotation |
 | `required` | no | If `true`, the tool should error when the source value is absent (default: `false`) |
-| `transform` | no | **Reserved, not yet implemented.** ID of a transform from `transforms/` to apply to the source value before writing to the target (e.g. `"datetime-tiff-to-iso8601"`) |
+| `transform` | no | Optional transform invocation. Can be a string ID for a simple one-input transform or an object that names the primary input, binds additional inputs, and passes parameters. |
 
 ### Source types
 
@@ -70,6 +70,52 @@ Injects a fixed literal value into the target field, regardless of the image con
 
 > **Note:** Spaces in property names do **not** need to be escaped in JSON Pointer — only `/` (as `~1`) and `~` (as `~0`) require escaping.
 
+### Transform invocation
+
+When a mapping includes a transform, the top-level `source` still provides the main value for the mapping. In the object form, `transform.primaryInput` names which transform input receives that source value.
+
+Use the string shorthand when the transform only needs that one primary input:
+
+```json
+{
+  "source": { "type": "tiff-tag", "id": 306, "name": "DateTime" },
+  "transform": "datetime-tiff-to-iso8601",
+  "target": "/General Section/Time Stamp"
+}
+```
+
+Use the object form when the transform needs more than one runtime input or when you want to pass transform parameters:
+
+```json
+{
+  "source": { "type": "tiff-tag", "id": 282, "name": "XResolution" },
+  "transform": {
+    "id": "resolution-to-nm-per-px",
+    "primaryInput": "resolution",
+    "inputs": {
+      "resolution_unit": { "type": "tiff-tag", "id": 296, "name": "ResolutionUnit" }
+    }
+  },
+  "target": "/General Section/Pixel Width/Value"
+}
+```
+
+If a transform definition declares optional parameters, pass them through `transform.parameters`:
+
+```json
+{
+  "source": { "type": "tiff-tag", "id": 306, "name": "DateTime" },
+  "transform": {
+    "id": "datetime-tiff-to-iso8601",
+    "primaryInput": "value",
+    "parameters": {
+      "timezone_offset": "+01:00"
+    }
+  },
+  "target": "/General Section/Time Stamp"
+}
+```
+
 ### Minimal connector example
 
 ```json
@@ -101,13 +147,16 @@ Injects a fixed literal value into the target field, regardless of the image con
 
 Some source values cannot be written directly to the FAMH target because their format differs from what the schema expects. In these cases a **transform** is needed to convert the value first.
 
-> **Transforms are not yet implemented.** The `transform` field is reserved in the connector schema. The transform definitions below document the planned conversions so that implementations are consistent once support is added.
+> **Tool support may still be partial.** The connector schema now defines how transform invocations are expressed, but consuming tools may not yet implement every transform or invocation feature.
 
 Transform definitions live in [`transforms/`](transforms/) and are validated against [`transforms/transform-schema.json`](transforms/transform-schema.json). Each file describes:
 
-- The input type and format
+- The runtime input set (`inputs`), including type and optional format hints
 - The output type and format
 - Any configurable parameters
+- Optional `appliesTo` scope for source-format-specific assumptions (for example TIFF)
+- Optional `behavior` rules for missing, invalid, or unknown values
+- Optional worked `examples`
 - Implementation notes and edge cases
 
 ### Available transform definitions
@@ -119,15 +168,36 @@ Transform definitions live in [`transforms/`](transforms/) and are validated aga
 | `resolution-to-nm-per-px` | [transforms/resolution-to-nm-per-px.json](transforms/resolution-to-nm-per-px.json) | Convert XResolution/YResolution + ResolutionUnit to nm/px |
 | `photometric-to-color-mode` | [transforms/photometric-to-color-mode.json](transforms/photometric-to-color-mode.json) | Map `PhotometricInterpretation` integer to FAMH Color Mode string |
 
-### Using a transform in a mapping (future syntax)
+The current transform catalog intentionally mixes generic transforms and TIFF-specific transforms:
 
-Once implemented, transforms will be referenced by ID in the mapping object:
+- `rational-to-float` is generic for any extractor that represents fractions as strings like `"N/D"`.
+- `datetime-tiff-to-iso8601`, `resolution-to-nm-per-px`, and `photometric-to-color-mode` are explicitly TIFF-specific and mark that via `appliesTo.sourceFormat` and TIFF-oriented `format` hints.
+
+### Using a transform in a mapping
+
+Simple one-input transforms can use the string shorthand:
 
 ```json
 {
   "source": { "type": "tiff-tag", "id": 306, "name": "DateTime" },
   "transform": "datetime-tiff-to-iso8601",
   "target": "/General Section/Time Stamp"
+}
+```
+
+Transforms with multiple runtime inputs should use the object form:
+
+```json
+{
+  "source": { "type": "tiff-tag", "id": 282, "name": "XResolution" },
+  "transform": {
+    "id": "resolution-to-nm-per-px",
+    "primaryInput": "resolution",
+    "inputs": {
+      "resolution_unit": { "type": "tiff-tag", "id": 296, "name": "ResolutionUnit" }
+    }
+  },
+  "target": "/General Section/Pixel Width/Value"
 }
 ```
 
@@ -185,7 +255,7 @@ Create a new JSON file in this directory (e.g. `my-tool.json`) referencing `conn
 }
 ```
 
-Map each extracted tag to the appropriate JSON Pointer target. For tags whose values need conversion, document them in `_pendingMappings` (like `tiff-standard.json`) until transform support is available.
+Map each extracted tag to the appropriate JSON Pointer target. For tags whose values need conversion, use a `transform` entry and bind any additional transform inputs or parameters that the transform definition requires.
 
 ### 3 – Validate the connector
 

--- a/connectors/README.md
+++ b/connectors/README.md
@@ -1,0 +1,200 @@
+# Connectors
+
+Connector files map metadata from image files (e.g. TIFF tags) to fields in the [FA Metadata Header (FAMH)](../README.md) schema. A connector is a plain JSON file that a tool such as [`famdo`](https://github.com/Failure-Analysis-Metadata-Header/famdo) can read to automatically populate an FAMH output document from image metadata.
+
+---
+
+## Connector File Format
+
+Each connector is a JSON object validated against [connector-schema.json](connector-schema.json).
+
+### Top-level fields
+
+| Field | Required | Description |
+|---|---|---|
+| `$schema` | recommended | URI to `connector-schema.json` |
+| `name` | yes | Human-readable connector name |
+| `version` | yes | Version string (e.g. `"1.0.0"`) |
+| `description` | no | What the connector does and which tool it targets |
+| `targetSchemaVersion` | yes | FAMH schema version: `"1"`, `"1.1"`, or `"2"` |
+| `mappings` | yes | Array of mapping objects (see below) |
+
+### Mapping objects
+
+Each entry in `mappings` has the following fields:
+
+| Field | Required | Description |
+|---|---|---|
+| `source` | yes | Where to read the value from (see Source types) |
+| `target` | yes | JSON Pointer (RFC 6901) to the field in the FAMH output document |
+| `description` | no | Human-readable annotation |
+| `required` | no | If `true`, the tool should error when the source value is absent (default: `false`) |
+| `transform` | no | **Reserved, not yet implemented.** ID of a transform from `transforms/` to apply to the source value before writing to the target (e.g. `"datetime-tiff-to-iso8601"`) |
+
+### Source types
+
+#### `tiff-tag`
+Reads the value of a named TIFF tag from the image file.
+
+```json
+{ "type": "tiff-tag", "name": "ImageWidth" }
+```
+
+- `name` is the tag name as it appears in the `tag` field of `famdo extract` output — the Rust debug representation of the TIFF tag enum (e.g. `"ImageWidth"`, `"Make"`, `"DateTime"`, `"BitsPerSample"`).
+- For unknown or private tags the form is `"Unknown(id)"` where `id` is the decimal tag number (e.g. `"Unknown(34682)"`).
+
+#### `constant`
+Injects a fixed literal value into the target field, regardless of the image content. Useful for units and other fields that are always the same for a given source format.
+
+```json
+{ "type": "constant", "value": "px" }
+```
+
+`value` may be any JSON type: string, number, boolean, array, or object.
+
+### Target paths
+
+`target` is a [JSON Pointer (RFC 6901)](https://datatracker.ietf.org/doc/html/rfc6901) into the FAMH output document. For FAMH v1.1 (which uses spaces in property names) the paths look like:
+
+```
+/General Section/File Name
+/General Section/Image Width/Value
+/General Section/Image Width/Unit
+/General Section/Manufacturer
+/General Section/Tool Name
+/General Section/Bit Depth
+/Method Specific/Scanning Electron Microscopy/Accelerating Voltage/Value
+/Data Evaluation/POI/0/Name
+```
+
+> **Note:** Spaces in property names do **not** need to be escaped in JSON Pointer — only `/` (as `~1`) and `~` (as `~0`) require escaping.
+
+### Minimal connector example
+
+```json
+{
+  "$schema": "./connector-schema.json",
+  "name": "My Tool Connector",
+  "version": "1.0.0",
+  "targetSchemaVersion": "1.1",
+  "mappings": [
+    {
+      "source": { "type": "tiff-tag", "name": "ImageWidth" },
+      "target": "/General Section/Image Width/Value"
+    },
+    {
+      "source": { "type": "constant", "value": "px" },
+      "target": "/General Section/Image Width/Unit"
+    },
+    {
+      "source": { "type": "tiff-tag", "name": "Make" },
+      "target": "/General Section/Manufacturer"
+    }
+  ]
+}
+```
+
+---
+
+## Transforms
+
+Some source values cannot be written directly to the FAMH target because their format differs from what the schema expects. In these cases a **transform** is needed to convert the value first.
+
+> **Transforms are not yet implemented.** The `transform` field is reserved in the connector schema. The transform definitions below document the planned conversions so that implementations are consistent once support is added.
+
+Transform definitions live in [`transforms/`](transforms/) and are validated against [`transforms/transform-schema.json`](transforms/transform-schema.json). Each file describes:
+
+- The input type and format
+- The output type and format
+- Any configurable parameters
+- Implementation notes and edge cases
+
+### Available transform definitions
+
+| Transform ID | File | Description |
+|---|---|---|
+| `datetime-tiff-to-iso8601` | [transforms/datetime-tiff-to-iso8601.json](transforms/datetime-tiff-to-iso8601.json) | Convert TIFF `DateTime` (`"YYYY:MM:DD HH:MM:SS"`) to ISO 8601 (`"YYYY-MM-DDTHH:MM:SS+HH:MM"`) |
+| `rational-to-float` | [transforms/rational-to-float.json](transforms/rational-to-float.json) | Convert TIFF rational string `"N/D"` to a floating-point number |
+| `resolution-to-nm-per-px` | [transforms/resolution-to-nm-per-px.json](transforms/resolution-to-nm-per-px.json) | Convert XResolution/YResolution + ResolutionUnit to nm/px |
+| `photometric-to-color-mode` | [transforms/photometric-to-color-mode.json](transforms/photometric-to-color-mode.json) | Map `PhotometricInterpretation` integer to FAMH Color Mode string |
+
+### Using a transform in a mapping (future syntax)
+
+Once implemented, transforms will be referenced by ID in the mapping object:
+
+```json
+{
+  "source": { "type": "tiff-tag", "name": "DateTime" },
+  "transform": "datetime-tiff-to-iso8601",
+  "target": "/General Section/Time Stamp"
+}
+```
+
+---
+
+## Available Connectors
+
+| File | Target version | Source | Description |
+|---|---|---|---|
+| [tiff-standard.json](tiff-standard.json) | v1.1 | Standard TIFF tags | Maps baseline TIFF 6.0 tags (ImageWidth, ImageLength, BitsPerSample, Make, Model) to FAMH fields. Tool-agnostic. |
+
+> Vendor-specific connectors (ZEISS, FEI/Thermo Fisher, Tescan, …) will be added to this directory as they are developed. Vendor tools typically embed rich acquisition parameters in private TIFF tags or in structured text within the `ImageDescription` tag (256), which will require an additional source type (`tiff-embedded-text`) and vendor-specific transform definitions.
+
+---
+
+## Writing a New Connector
+
+### 1 – Extract tag names from your image
+
+Use `famdo extract` to see what tags are present in a sample image and what values they contain:
+
+```bash
+famdo extract my_image.tif -o extracted.json
+```
+
+The output JSON has the structure:
+
+```json
+{
+  "filename": "my_image.tif",
+  "dimensions": { "width": 1024, "height": 768 },
+  "tags": [
+    { "tag": "ImageWidth",  "value": 1024,   "type": "Short" },
+    { "tag": "Make",        "value": "ZEISS", "type": "ASCII" },
+    { "tag": "DateTime",    "value": "2025:12:09 14:30:00", "type": "ASCII" }
+  ]
+}
+```
+
+Use the `tag` string values directly as `name` in `tiff-tag` source objects.
+
+### 2 – Create the connector file
+
+Create a new JSON file in this directory (e.g. `my-tool.json`) referencing `connector-schema.json`:
+
+```json
+{
+  "$schema": "./connector-schema.json",
+  "name": "My Tool",
+  "version": "1.0.0",
+  "targetSchemaVersion": "1.1",
+  "mappings": [...]
+}
+```
+
+Map each extracted tag to the appropriate JSON Pointer target. For tags whose values need conversion, document them in `_pendingMappings` (like `tiff-standard.json`) until transform support is available.
+
+### 3 – Validate the connector
+
+Validate your connector against the schema using any JSON Schema Draft 07 validator, for example:
+
+```bash
+python3 -c "
+import json, jsonschema
+schema = json.load(open('connector-schema.json'))
+data   = json.load(open('my-tool.json'))
+jsonschema.validate(data, schema)
+print('Valid')
+"
+```
+

--- a/connectors/README.md
+++ b/connectors/README.md
@@ -34,14 +34,15 @@ Each entry in `mappings` has the following fields:
 ### Source types
 
 #### `tiff-tag`
-Reads the value of a named TIFF tag from the image file.
+Reads the value of a TIFF tag from the image file.
 
 ```json
-{ "type": "tiff-tag", "name": "ImageWidth" }
+{ "type": "tiff-tag", "id": 256, "name": "ImageWidth" }
 ```
 
-- `name` is the tag name as it appears in the `tag` field of `famdo extract` output — the Rust debug representation of the TIFF tag enum (e.g. `"ImageWidth"`, `"Make"`, `"DateTime"`, `"BitsPerSample"`).
-- For unknown or private tags the form is `"Unknown(id)"` where `id` is the decimal tag number (e.g. `"Unknown(34682)"`).
+- `id` is the canonical TIFF tag ID and should be used for matching across tools. Standard tags keep the same numeric ID regardless of extractor.
+- `name` is optional and is kept for readability and documentation. Tools should treat it as informational.
+- When a tool exposes both numeric IDs and human-readable names, connector authors should include both.
 
 #### `constant`
 Injects a fixed literal value into the target field, regardless of the image content. Useful for units and other fields that are always the same for a given source format.
@@ -79,7 +80,7 @@ Injects a fixed literal value into the target field, regardless of the image con
   "targetSchemaVersion": "1.1",
   "mappings": [
     {
-      "source": { "type": "tiff-tag", "name": "ImageWidth" },
+      "source": { "type": "tiff-tag", "id": 256, "name": "ImageWidth" },
       "target": "/General Section/Image Width/Value"
     },
     {
@@ -87,7 +88,7 @@ Injects a fixed literal value into the target field, regardless of the image con
       "target": "/General Section/Image Width/Unit"
     },
     {
-      "source": { "type": "tiff-tag", "name": "Make" },
+      "source": { "type": "tiff-tag", "id": 271, "name": "Make" },
       "target": "/General Section/Manufacturer"
     }
   ]
@@ -124,7 +125,7 @@ Once implemented, transforms will be referenced by ID in the mapping object:
 
 ```json
 {
-  "source": { "type": "tiff-tag", "name": "DateTime" },
+  "source": { "type": "tiff-tag", "id": 306, "name": "DateTime" },
   "transform": "datetime-tiff-to-iso8601",
   "target": "/General Section/Time Stamp"
 }
@@ -146,7 +147,7 @@ Once implemented, transforms will be referenced by ID in the mapping object:
 
 ### 1 – Extract tag names from your image
 
-Use `famdo extract` to see what tags are present in a sample image and what values they contain:
+Use `famdo extract` to see what tags are present in a sample image and what values they contain. `famdo` is a convenient reference extractor, but other TIFF tools can be used too as long as they expose the raw TIFF tag IDs:
 
 ```bash
 famdo extract my_image.tif -o extracted.json
@@ -167,6 +168,8 @@ The output JSON has the structure:
 ```
 
 Use the `tag` string values directly as `name` in `tiff-tag` source objects.
+
+The connector should still use the numeric TIFF tag ID as the canonical identifier. If your extractor reports IDs separately, copy those into `id` and keep the human-readable name in `name`. If your extractor reports only names, you should look up the corresponding TIFF tag IDs before finalizing the connector.
 
 ### 2 – Create the connector file
 

--- a/connectors/connector-schema.json
+++ b/connectors/connector-schema.json
@@ -91,17 +91,22 @@
             "type": "object",
             "required": [
                 "type",
-                "name"
+                "id"
             ],
             "additionalProperties": false,
             "properties": {
                 "type": {
                     "const": "tiff-tag",
-                    "description": "Read the value from a named TIFF tag"
+                    "description": "Read the value from a TIFF tag identified by its numeric tag ID"
+                },
+                "id": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Canonical TIFF tag ID (for example 256 for ImageWidth, 271 for Make). Use the numeric ID for reliable cross-tool identification."
                 },
                 "name": {
                     "type": "string",
-                    "description": "TIFF tag name as it appears in the 'tag' field of `famdo extract` output (Rust debug representation of the tag enum, e.g. \"ImageWidth\", \"Make\", \"DateTime\"). For unknown/private tags use the form \"Unknown(id)\" where id is the decimal tag number."
+                    "description": "Optional human-readable TIFF tag name for readability and documentation (for example \"ImageWidth\", \"Make\", \"DateTime\"). Tools should use `id` for matching and treat `name` as informational."
                 }
             }
         },

--- a/connectors/connector-schema.json
+++ b/connectors/connector-schema.json
@@ -1,0 +1,126 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "connector-schema.json",
+    "title": "FA Metadata Header – Connector File",
+    "description": "Defines the structure of a connector file that maps metadata sources (e.g. TIFF tags) to fields in the FAMH output document.",
+    "version": "1.0.0",
+    "type": "object",
+    "required": [
+        "name",
+        "version",
+        "targetSchemaVersion",
+        "mappings"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "$schema": {
+            "type": "string",
+            "description": "URI of the connector schema (connector-schema.json)"
+        },
+        "name": {
+            "type": "string",
+            "description": "Human-readable connector name"
+        },
+        "version": {
+            "type": "string",
+            "description": "Connector version string (e.g. \"1.0.0\")"
+        },
+        "description": {
+            "type": "string",
+            "description": "What this connector does and which tool or source format it targets"
+        },
+        "targetSchemaVersion": {
+            "type": "string",
+            "description": "FAMH schema version this connector targets",
+            "enum": [
+                "1",
+                "1.1",
+                "2"
+            ]
+        },
+        "mappings": {
+            "type": "array",
+            "description": "Ordered list of source-to-target field mappings",
+            "items": {
+                "$ref": "#/definitions/mapping"
+            }
+        }
+    },
+    "definitions": {
+        "mapping": {
+            "type": "object",
+            "required": [
+                "source",
+                "target"
+            ],
+            "description": "A single field mapping from a source value to a target FAMH field. The reserved property 'transform' (not yet enforced) will reference a named transform from the transforms/ directory (e.g. \"transform\": \"datetime-tiff-to-iso8601\") once transform support is implemented.",
+            "properties": {
+                "source": {
+                    "description": "Origin of the value to write to the target field",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/tiffTagSource"
+                        },
+                        {
+                            "$ref": "#/definitions/constantSource"
+                        }
+                    ]
+                },
+                "target": {
+                    "type": "string",
+                    "description": "JSON Pointer (RFC 6901) to the target field in the FAMH output document. Example: \"/General Section/Image Width/Value\"",
+                    "pattern": "^/"
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Optional human-readable description of this mapping"
+                },
+                "required": {
+                    "type": "boolean",
+                    "description": "Whether the mapping tool should error if the source value is absent",
+                    "default": false
+                },
+                "transform": {
+                    "type": "string",
+                    "description": "Reserved for future use. ID of a transform from transforms/ to apply to the source value before writing to the target (e.g. \"datetime-tiff-to-iso8601\")."
+                }
+            },
+            "additionalProperties": false
+        },
+        "tiffTagSource": {
+            "type": "object",
+            "required": [
+                "type",
+                "name"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "const": "tiff-tag",
+                    "description": "Read the value from a named TIFF tag"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "TIFF tag name as it appears in the 'tag' field of `famdo extract` output (Rust debug representation of the tag enum, e.g. \"ImageWidth\", \"Make\", \"DateTime\"). For unknown/private tags use the form \"Unknown(id)\" where id is the decimal tag number."
+                }
+            }
+        },
+        "constantSource": {
+            "type": "object",
+            "required": [
+                "type",
+                "value"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "const": "constant",
+                    "description": "Inject a fixed literal value into the target field"
+                },
+                "value": {
+                    "description": "The fixed value to write. May be a string, number, boolean, array, or object."
+                }
+            }
+        }
+    }
+}

--- a/connectors/connector-schema.json
+++ b/connectors/connector-schema.json
@@ -53,18 +53,10 @@
                 "source",
                 "target"
             ],
-            "description": "A single field mapping from a source value to a target FAMH field. The reserved property 'transform' (not yet enforced) will reference a named transform from the transforms/ directory (e.g. \"transform\": \"datetime-tiff-to-iso8601\") once transform support is implemented.",
+            "description": "A single field mapping from a source value to a target FAMH field. The optional `transform` property references a transform definition from transforms/ and may also bind additional named inputs or parameters.",
             "properties": {
                 "source": {
-                    "description": "Origin of the value to write to the target field",
-                    "oneOf": [
-                        {
-                            "$ref": "#/definitions/tiffTagSource"
-                        },
-                        {
-                            "$ref": "#/definitions/constantSource"
-                        }
-                    ]
+                    "$ref": "#/definitions/sourceSpec"
                 },
                 "target": {
                     "type": "string",
@@ -81,11 +73,59 @@
                     "default": false
                 },
                 "transform": {
-                    "type": "string",
-                    "description": "Reserved for future use. ID of a transform from transforms/ to apply to the source value before writing to the target (e.g. \"datetime-tiff-to-iso8601\")."
+                    "description": "Optional transform to apply before writing to the target. Use the string shorthand for simple one-input transforms, or the object form when you need to name the primary input, bind additional inputs, or pass parameters.",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "$ref": "#/definitions/transformInvocation"
+                        }
+                    ]
                 }
             },
             "additionalProperties": false
+        },
+        "sourceSpec": {
+            "description": "Origin of a value used by a mapping or a transform input binding",
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/tiffTagSource"
+                },
+                {
+                    "$ref": "#/definitions/constantSource"
+                }
+            ]
+        },
+        "transformInvocation": {
+            "type": "object",
+            "required": [
+                "id",
+                "primaryInput"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Transform definition ID from the transforms/ directory."
+                },
+                "primaryInput": {
+                    "type": "string",
+                    "description": "Name of the transform input that receives the mapping's top-level `source` value."
+                },
+                "inputs": {
+                    "type": "object",
+                    "description": "Optional additional named transform inputs. Each property name is a transform input name and each value is a source specification.",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/sourceSpec"
+                    }
+                },
+                "parameters": {
+                    "type": "object",
+                    "description": "Optional transform parameters keyed by parameter name. Values may be any JSON literals understood by the consuming tool.",
+                    "additionalProperties": true
+                }
+            }
         },
         "tiffTagSource": {
             "type": "object",

--- a/connectors/mappings/tiff-standard.json
+++ b/connectors/mappings/tiff-standard.json
@@ -2,7 +2,7 @@
     "$schema": "./connector-schema.json",
     "name": "Standard TIFF Tags",
     "version": "1.0.0",
-    "description": "Maps baseline TIFF 6.0 standard tags to FAMH v1.1 fields. Only covers tags that can be written to the target without value transformation. Tags that require conversion (DateTime, XResolution/YResolution, PhotometricInterpretation) are listed as comments below and will be supported once the 'transform' field is implemented — see connectors/transforms/ for their definitions.",
+    "description": "Maps baseline TIFF 6.0 standard tags to FAMH v1.1 fields. Direct mappings are included for fields that can be copied as-is, and transform invocations are included for fields that require conversion such as DateTime, XResolution/YResolution, and PhotometricInterpretation.",
     "targetSchemaVersion": "1.1",
     "mappings": [
         {
@@ -67,48 +67,88 @@
             "target": "/General Section/Tool Name",
             "description": "TIFF tag 272: equipment model name (e.g. \"GeminiSEM 500\")",
             "required": false
-        }
-    ],
-    "_pendingMappings": [
+        },
         {
-            "_note": "Requires transform 'datetime-tiff-to-iso8601'. TIFF DateTime format is 'YYYY:MM:DD HH:MM:SS' (no timezone); ISO 8601 is required by FAMH.",
             "source": {
                 "type": "tiff-tag",
                 "id": 306,
                 "name": "DateTime"
             },
-            "transform": "datetime-tiff-to-iso8601",
-            "target": "/General Section/Time Stamp"
+            "transform": {
+                "id": "datetime-tiff-to-iso8601",
+                "primaryInput": "value"
+            },
+            "target": "/General Section/Time Stamp",
+            "description": "TIFF tag 306: capture timestamp converted from TIFF DateTime format to ISO 8601"
         },
         {
-            "_note": "Requires transform 'resolution-to-nm-per-px'. XResolution is a rational (pixels/inch or pixels/cm depending on ResolutionUnit tag). Most SEM tools set ResolutionUnit=1 (no absolute unit), making this meaningless — use vendor-specific tags instead.",
             "source": {
                 "type": "tiff-tag",
                 "id": 282,
                 "name": "XResolution"
             },
-            "transform": "resolution-to-nm-per-px",
-            "target": "/General Section/Pixel Width/Value"
+            "transform": {
+                "id": "resolution-to-nm-per-px",
+                "primaryInput": "resolution",
+                "inputs": {
+                    "resolution_unit": {
+                        "type": "tiff-tag",
+                        "id": 296,
+                        "name": "ResolutionUnit"
+                    }
+                }
+            },
+            "target": "/General Section/Pixel Width/Value",
+            "description": "TIFF tag 282 combined with tag 296: convert XResolution and ResolutionUnit into a pixel width value"
         },
         {
-            "_note": "Requires transform 'resolution-to-nm-per-px'. See XResolution note above.",
+            "source": {
+                "type": "constant",
+                "value": "nm"
+            },
+            "target": "/General Section/Pixel Width/Unit",
+            "description": "FAMH Pixel Width should preferably use nanometres as its unit"
+        },
+        {
             "source": {
                 "type": "tiff-tag",
                 "id": 283,
                 "name": "YResolution"
             },
-            "transform": "resolution-to-nm-per-px",
-            "target": "/General Section/Pixel Height/Value"
+            "transform": {
+                "id": "resolution-to-nm-per-px",
+                "primaryInput": "resolution",
+                "inputs": {
+                    "resolution_unit": {
+                        "type": "tiff-tag",
+                        "id": 296,
+                        "name": "ResolutionUnit"
+                    }
+                }
+            },
+            "target": "/General Section/Pixel Height/Value",
+            "description": "TIFF tag 283 combined with tag 296: convert YResolution and ResolutionUnit into a pixel height value"
         },
         {
-            "_note": "Requires transform 'photometric-to-color-mode'. PhotometricInterpretation is an integer (0/1=Grayscale, 2=RGB, 3=Palette, 6=YCbCr) that must be mapped to the FAMH color mode string.",
+            "source": {
+                "type": "constant",
+                "value": "nm"
+            },
+            "target": "/General Section/Pixel Height/Unit",
+            "description": "FAMH Pixel Height should preferably use nanometres as its unit"
+        },
+        {
             "source": {
                 "type": "tiff-tag",
                 "id": 262,
                 "name": "PhotometricInterpretation"
             },
-            "transform": "photometric-to-color-mode",
-            "target": "/General Section/Color Mode"
+            "transform": {
+                "id": "photometric-to-color-mode",
+                "primaryInput": "value"
+            },
+            "target": "/General Section/Color Mode",
+            "description": "TIFF tag 262: map PhotometricInterpretation to the FAMH Color Mode string"
         }
     ]
 }

--- a/connectors/tiff-standard.json
+++ b/connectors/tiff-standard.json
@@ -8,6 +8,7 @@
         {
             "source": {
                 "type": "tiff-tag",
+                "id": 256,
                 "name": "ImageWidth"
             },
             "target": "/General Section/Image Width/Value",
@@ -24,6 +25,7 @@
         {
             "source": {
                 "type": "tiff-tag",
+                "id": 257,
                 "name": "ImageLength"
             },
             "target": "/General Section/Image Height/Value",
@@ -40,6 +42,7 @@
         {
             "source": {
                 "type": "tiff-tag",
+                "id": 258,
                 "name": "BitsPerSample"
             },
             "target": "/General Section/Bit Depth",
@@ -48,6 +51,7 @@
         {
             "source": {
                 "type": "tiff-tag",
+                "id": 271,
                 "name": "Make"
             },
             "target": "/General Section/Manufacturer",
@@ -57,6 +61,7 @@
         {
             "source": {
                 "type": "tiff-tag",
+                "id": 272,
                 "name": "Model"
             },
             "target": "/General Section/Tool Name",
@@ -69,6 +74,7 @@
             "_note": "Requires transform 'datetime-tiff-to-iso8601'. TIFF DateTime format is 'YYYY:MM:DD HH:MM:SS' (no timezone); ISO 8601 is required by FAMH.",
             "source": {
                 "type": "tiff-tag",
+                "id": 306,
                 "name": "DateTime"
             },
             "transform": "datetime-tiff-to-iso8601",
@@ -78,6 +84,7 @@
             "_note": "Requires transform 'resolution-to-nm-per-px'. XResolution is a rational (pixels/inch or pixels/cm depending on ResolutionUnit tag). Most SEM tools set ResolutionUnit=1 (no absolute unit), making this meaningless — use vendor-specific tags instead.",
             "source": {
                 "type": "tiff-tag",
+                "id": 282,
                 "name": "XResolution"
             },
             "transform": "resolution-to-nm-per-px",
@@ -87,6 +94,7 @@
             "_note": "Requires transform 'resolution-to-nm-per-px'. See XResolution note above.",
             "source": {
                 "type": "tiff-tag",
+                "id": 283,
                 "name": "YResolution"
             },
             "transform": "resolution-to-nm-per-px",
@@ -96,6 +104,7 @@
             "_note": "Requires transform 'photometric-to-color-mode'. PhotometricInterpretation is an integer (0/1=Grayscale, 2=RGB, 3=Palette, 6=YCbCr) that must be mapped to the FAMH color mode string.",
             "source": {
                 "type": "tiff-tag",
+                "id": 262,
                 "name": "PhotometricInterpretation"
             },
             "transform": "photometric-to-color-mode",

--- a/connectors/tiff-standard.json
+++ b/connectors/tiff-standard.json
@@ -1,0 +1,105 @@
+{
+    "$schema": "./connector-schema.json",
+    "name": "Standard TIFF Tags",
+    "version": "1.0.0",
+    "description": "Maps baseline TIFF 6.0 standard tags to FAMH v1.1 fields. Only covers tags that can be written to the target without value transformation. Tags that require conversion (DateTime, XResolution/YResolution, PhotometricInterpretation) are listed as comments below and will be supported once the 'transform' field is implemented — see connectors/transforms/ for their definitions.",
+    "targetSchemaVersion": "1.1",
+    "mappings": [
+        {
+            "source": {
+                "type": "tiff-tag",
+                "name": "ImageWidth"
+            },
+            "target": "/General Section/Image Width/Value",
+            "description": "TIFF tag 256: image width in pixels"
+        },
+        {
+            "source": {
+                "type": "constant",
+                "value": "px"
+            },
+            "target": "/General Section/Image Width/Unit",
+            "description": "Image Width unit is always pixels when sourced from TIFF"
+        },
+        {
+            "source": {
+                "type": "tiff-tag",
+                "name": "ImageLength"
+            },
+            "target": "/General Section/Image Height/Value",
+            "description": "TIFF tag 257: image height in pixels"
+        },
+        {
+            "source": {
+                "type": "constant",
+                "value": "px"
+            },
+            "target": "/General Section/Image Height/Unit",
+            "description": "Image Height unit is always pixels when sourced from TIFF"
+        },
+        {
+            "source": {
+                "type": "tiff-tag",
+                "name": "BitsPerSample"
+            },
+            "target": "/General Section/Bit Depth",
+            "description": "TIFF tag 258: number of bits per sample/channel (e.g. 8, 16)"
+        },
+        {
+            "source": {
+                "type": "tiff-tag",
+                "name": "Make"
+            },
+            "target": "/General Section/Manufacturer",
+            "description": "TIFF tag 271: equipment manufacturer (e.g. \"ZEISS\", \"FEI\")",
+            "required": false
+        },
+        {
+            "source": {
+                "type": "tiff-tag",
+                "name": "Model"
+            },
+            "target": "/General Section/Tool Name",
+            "description": "TIFF tag 272: equipment model name (e.g. \"GeminiSEM 500\")",
+            "required": false
+        }
+    ],
+    "_pendingMappings": [
+        {
+            "_note": "Requires transform 'datetime-tiff-to-iso8601'. TIFF DateTime format is 'YYYY:MM:DD HH:MM:SS' (no timezone); ISO 8601 is required by FAMH.",
+            "source": {
+                "type": "tiff-tag",
+                "name": "DateTime"
+            },
+            "transform": "datetime-tiff-to-iso8601",
+            "target": "/General Section/Time Stamp"
+        },
+        {
+            "_note": "Requires transform 'resolution-to-nm-per-px'. XResolution is a rational (pixels/inch or pixels/cm depending on ResolutionUnit tag). Most SEM tools set ResolutionUnit=1 (no absolute unit), making this meaningless — use vendor-specific tags instead.",
+            "source": {
+                "type": "tiff-tag",
+                "name": "XResolution"
+            },
+            "transform": "resolution-to-nm-per-px",
+            "target": "/General Section/Pixel Width/Value"
+        },
+        {
+            "_note": "Requires transform 'resolution-to-nm-per-px'. See XResolution note above.",
+            "source": {
+                "type": "tiff-tag",
+                "name": "YResolution"
+            },
+            "transform": "resolution-to-nm-per-px",
+            "target": "/General Section/Pixel Height/Value"
+        },
+        {
+            "_note": "Requires transform 'photometric-to-color-mode'. PhotometricInterpretation is an integer (0/1=Grayscale, 2=RGB, 3=Palette, 6=YCbCr) that must be mapped to the FAMH color mode string.",
+            "source": {
+                "type": "tiff-tag",
+                "name": "PhotometricInterpretation"
+            },
+            "transform": "photometric-to-color-mode",
+            "target": "/General Section/Color Mode"
+        }
+    ]
+}

--- a/connectors/transforms/datetime-tiff-to-iso8601.json
+++ b/connectors/transforms/datetime-tiff-to-iso8601.json
@@ -3,13 +3,22 @@
     "id": "datetime-tiff-to-iso8601",
     "name": "TIFF DateTime to ISO 8601",
     "description": "Converts a TIFF DateTime string to an ISO 8601 datetime string. The TIFF 6.0 specification defines DateTime (tag 306) as a fixed-length ASCII string in the format 'YYYY:MM:DD HH:MM:SS'. ISO 8601 — required by the FAMH Time Stamp field — uses 'YYYY-MM-DDTHH:MM:SS' and optionally includes a timezone offset. Because TIFF DateTime carries no timezone information, the offset must be supplied as a parameter or omitted (resulting in a naive datetime string).",
-    "input": {
-        "type": "string",
-        "description": "TIFF DateTime string as returned by `famdo extract`. Format: 'YYYY:MM:DD HH:MM:SS' (fixed 19 characters, colons as date separators).",
-        "example": "2025:12:09 14:30:00"
+    "appliesTo": {
+        "sourceFormat": "TIFF",
+        "targetConvention": "FAMH Time Stamp"
     },
+    "inputs": [
+        {
+            "name": "value",
+            "type": "string",
+            "format": "tiff-datetime",
+            "description": "TIFF DateTime string. Format: 'YYYY:MM:DD HH:MM:SS' (fixed 19 characters, colons as date separators).",
+            "example": "2025:12:09 14:30:00"
+        }
+    ],
     "output": {
         "type": "string",
+        "format": "iso8601-date-time",
         "description": "ISO 8601 datetime string. Format: 'YYYY-MM-DDTHH:MM:SS[+HH:MM]'.",
         "example": "2025-12-09T14:30:00+01:00"
     },
@@ -17,9 +26,26 @@
         {
             "name": "timezone_offset",
             "type": "string",
+            "format": "utc-offset",
             "description": "UTC offset to append to the output, e.g. \"+01:00\" or \"Z\". If omitted the output has no timezone suffix (naive datetime).",
             "required": false,
-            "default": null
+            "default": ""
+        }
+    ],
+    "behavior": {
+        "onMissingInput": "error",
+        "onInvalidInput": "error"
+    },
+    "examples": [
+        {
+            "description": "Convert a TIFF DateTime string with an explicit timezone.",
+            "inputs": {
+                "value": "2025:12:09 14:30:00"
+            },
+            "parameters": {
+                "timezone_offset": "+01:00"
+            },
+            "output": "2025-12-09T14:30:00+01:00"
         }
     ],
     "notes": "Replacement rules: replace the first two colons in the date part with dashes, replace the space separator with 'T', then append the timezone offset if provided. Example: '2025:12:09 14:30:00' + offset '+01:00' → '2025-12-09T14:30:00+01:00'."

--- a/connectors/transforms/datetime-tiff-to-iso8601.json
+++ b/connectors/transforms/datetime-tiff-to-iso8601.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "./transform-schema.json",
+    "id": "datetime-tiff-to-iso8601",
+    "name": "TIFF DateTime to ISO 8601",
+    "description": "Converts a TIFF DateTime string to an ISO 8601 datetime string. The TIFF 6.0 specification defines DateTime (tag 306) as a fixed-length ASCII string in the format 'YYYY:MM:DD HH:MM:SS'. ISO 8601 — required by the FAMH Time Stamp field — uses 'YYYY-MM-DDTHH:MM:SS' and optionally includes a timezone offset. Because TIFF DateTime carries no timezone information, the offset must be supplied as a parameter or omitted (resulting in a naive datetime string).",
+    "input": {
+        "type": "string",
+        "description": "TIFF DateTime string as returned by `famdo extract`. Format: 'YYYY:MM:DD HH:MM:SS' (fixed 19 characters, colons as date separators).",
+        "example": "2025:12:09 14:30:00"
+    },
+    "output": {
+        "type": "string",
+        "description": "ISO 8601 datetime string. Format: 'YYYY-MM-DDTHH:MM:SS[+HH:MM]'.",
+        "example": "2025-12-09T14:30:00+01:00"
+    },
+    "parameters": [
+        {
+            "name": "timezone_offset",
+            "type": "string",
+            "description": "UTC offset to append to the output, e.g. \"+01:00\" or \"Z\". If omitted the output has no timezone suffix (naive datetime).",
+            "required": false,
+            "default": null
+        }
+    ],
+    "notes": "Replacement rules: replace the first two colons in the date part with dashes, replace the space separator with 'T', then append the timezone offset if provided. Example: '2025:12:09 14:30:00' + offset '+01:00' → '2025-12-09T14:30:00+01:00'."
+}

--- a/connectors/transforms/photometric-to-color-mode.json
+++ b/connectors/transforms/photometric-to-color-mode.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "./transform-schema.json",
+    "id": "photometric-to-color-mode",
+    "name": "TIFF PhotometricInterpretation to Color Mode",
+    "description": "Maps the integer value of the TIFF PhotometricInterpretation tag (tag 262) to the FAMH Color Mode string. Most FA images are grayscale (SEM, FIB) or RGB (optical), so only the common values are mapped. Unknown or uncommon values are represented as their integer string fallback.",
+    "input": {
+        "type": "integer",
+        "description": "PhotometricInterpretation tag value as an integer. Common values: 0 = WhiteIsZero, 1 = BlackIsZero, 2 = RGB, 3 = Palette/Indexed, 4 = TransparencyMask, 6 = YCbCr, 32803 = CFA (RAW).",
+        "example": 1
+    },
+    "output": {
+        "type": "string",
+        "description": "FAMH Color Mode string.",
+        "example": "Grayscale"
+    },
+    "parameters": [],
+    "notes": "Lookup table: 0 → \"Grayscale\" (white is zero), 1 → \"Grayscale\" (black is zero — the normal case for SEM/FIB), 2 → \"RGB\", 3 → \"Palette\", 6 → \"YCbCr\", any other value → the integer cast to string as a fallback. The distinction between WhiteIsZero (0) and BlackIsZero (1) is lost in the output; both map to \"Grayscale\"."
+}

--- a/connectors/transforms/photometric-to-color-mode.json
+++ b/connectors/transforms/photometric-to-color-mode.json
@@ -3,16 +3,45 @@
     "id": "photometric-to-color-mode",
     "name": "TIFF PhotometricInterpretation to Color Mode",
     "description": "Maps the integer value of the TIFF PhotometricInterpretation tag (tag 262) to the FAMH Color Mode string. Most FA images are grayscale (SEM, FIB) or RGB (optical), so only the common values are mapped. Unknown or uncommon values are represented as their integer string fallback.",
-    "input": {
-        "type": "integer",
-        "description": "PhotometricInterpretation tag value as an integer. Common values: 0 = WhiteIsZero, 1 = BlackIsZero, 2 = RGB, 3 = Palette/Indexed, 4 = TransparencyMask, 6 = YCbCr, 32803 = CFA (RAW).",
-        "example": 1
+    "appliesTo": {
+        "sourceFormat": "TIFF",
+        "targetConvention": "FAMH Color Mode"
     },
+    "inputs": [
+        {
+            "name": "value",
+            "type": "integer",
+            "format": "tiff-photometric-interpretation",
+            "description": "PhotometricInterpretation tag value as an integer. Common values: 0 = WhiteIsZero, 1 = BlackIsZero, 2 = RGB, 3 = Palette/Indexed, 4 = TransparencyMask, 6 = YCbCr, 32803 = CFA (RAW).",
+            "example": 1
+        }
+    ],
     "output": {
         "type": "string",
         "description": "FAMH Color Mode string.",
         "example": "Grayscale"
     },
     "parameters": [],
+    "behavior": {
+        "onMissingInput": "error",
+        "onInvalidInput": "error",
+        "onUnknownValue": "string-fallback"
+    },
+    "examples": [
+        {
+            "description": "Standard SEM/FIB grayscale encoding.",
+            "inputs": {
+                "value": 1
+            },
+            "output": "Grayscale"
+        },
+        {
+            "description": "Unknown value falls back to its string representation.",
+            "inputs": {
+                "value": 32803
+            },
+            "output": "32803"
+        }
+    ],
     "notes": "Lookup table: 0 → \"Grayscale\" (white is zero), 1 → \"Grayscale\" (black is zero — the normal case for SEM/FIB), 2 → \"RGB\", 3 → \"Palette\", 6 → \"YCbCr\", any other value → the integer cast to string as a fallback. The distinction between WhiteIsZero (0) and BlackIsZero (1) is lost in the output; both map to \"Grayscale\"."
 }

--- a/connectors/transforms/rational-to-float.json
+++ b/connectors/transforms/rational-to-float.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "./transform-schema.json",
+    "id": "rational-to-float",
+    "name": "Rational String to Float",
+    "description": "Converts a TIFF rational value — as produced by `famdo extract` — from its string representation 'numerator/denominator' to a floating-point number. The TIFF spec encodes rational numbers as two LONGs (numerator and denominator). famdo extract serialises these as the string 'N/D'. This transform performs the division and returns the result as a JSON number. Useful as a prerequisite step before resolution-to-nm-per-px.",
+    "input": {
+        "type": "rational",
+        "description": "Rational string as returned by `famdo extract` for Rational-type tags. Format: '<numerator>/<denominator>' where both parts are non-negative integers.",
+        "example": "96000/1000"
+    },
+    "output": {
+        "type": "number",
+        "description": "Floating-point result of numerator ÷ denominator.",
+        "example": 96.0
+    },
+    "parameters": [],
+    "notes": "Division by zero (denominator = 0) is an error condition that must be handled by the implementation. The result is a 64-bit IEEE 754 double."
+}

--- a/connectors/transforms/rational-to-float.json
+++ b/connectors/transforms/rational-to-float.json
@@ -2,17 +2,34 @@
     "$schema": "./transform-schema.json",
     "id": "rational-to-float",
     "name": "Rational String to Float",
-    "description": "Converts a TIFF rational value — as produced by `famdo extract` — from its string representation 'numerator/denominator' to a floating-point number. The TIFF spec encodes rational numbers as two LONGs (numerator and denominator). famdo extract serialises these as the string 'N/D'. This transform performs the division and returns the result as a JSON number. Useful as a prerequisite step before resolution-to-nm-per-px.",
-    "input": {
-        "type": "rational",
-        "description": "Rational string as returned by `famdo extract` for Rational-type tags. Format: '<numerator>/<denominator>' where both parts are non-negative integers.",
-        "example": "96000/1000"
-    },
+    "description": "Converts a string-encoded fraction in the form 'numerator/denominator' to a floating-point number. This is useful for TIFF rational values when an extractor serialises them as a string fraction, but the transform itself is not limited to TIFF.",
+    "inputs": [
+        {
+            "name": "value",
+            "type": "string",
+            "format": "fraction",
+            "description": "String fraction in the form '<numerator>/<denominator>' where both parts are integers.",
+            "example": "96000/1000"
+        }
+    ],
     "output": {
         "type": "number",
         "description": "Floating-point result of numerator ÷ denominator.",
         "example": 96.0
     },
     "parameters": [],
-    "notes": "Division by zero (denominator = 0) is an error condition that must be handled by the implementation. The result is a 64-bit IEEE 754 double."
+    "behavior": {
+        "onMissingInput": "error",
+        "onInvalidInput": "error"
+    },
+    "examples": [
+        {
+            "description": "Converts a TIFF-style fraction string to a number.",
+            "inputs": {
+                "value": "96000/1000"
+            },
+            "output": 96.0
+        }
+    ],
+    "notes": "Division by zero (denominator = 0) is an error condition that must be handled by the implementation. If an extractor already emits rationals as structured objects, arrays, or floating-point numbers, normalize them before using this transform."
 }

--- a/connectors/transforms/resolution-to-nm-per-px.json
+++ b/connectors/transforms/resolution-to-nm-per-px.json
@@ -2,24 +2,48 @@
     "$schema": "./transform-schema.json",
     "id": "resolution-to-nm-per-px",
     "name": "TIFF Resolution to nm/px",
-    "description": "Converts a TIFF XResolution or YResolution rational value (pixels per unit) combined with the ResolutionUnit tag into a pixel size in nanometres per pixel (nm/px) as expected by the FAMH Pixel Width/Pixel Height fields. The conversion is: nm_per_px = unit_in_nm / (resolution_in_pixels_per_unit). Important caveat: most SEM and FIB tools store calibrated pixel size in a vendor-specific TIFF tag and set ResolutionUnit=1 ('No absolute unit of measurement'), which makes this transform inapplicable. In those cases, use the vendor-specific connector instead.",
-    "input": {
-        "type": "rational",
-        "description": "XResolution or YResolution rational string as returned by `famdo extract` (e.g. '96000/1000', meaning 96 pixels per unit). The resolution unit is provided via the 'resolution_unit' parameter.",
-        "example": "96000/1000"
+    "description": "Converts a resolution value expressed in pixels per unit plus its associated unit code into a pixel size in nanometres per pixel (nm/px) as expected by the FAMH Pixel Width and Pixel Height fields. This definition is TIFF-specific because it assumes TIFF ResolutionUnit semantics. Important caveat: most SEM and FIB tools store calibrated pixel size in a vendor-specific TIFF tag and set ResolutionUnit=1 ('No absolute unit of measurement'), which makes this transform inapplicable.",
+    "appliesTo": {
+        "sourceFormat": "TIFF",
+        "targetConvention": "FAMH Pixel Width/Pixel Height"
     },
-    "output": {
-        "type": "number",
-        "description": "Pixel size in nm/px.",
-        "example": 264.58
-    },
-    "parameters": [
+    "inputs": [
+        {
+            "name": "resolution",
+            "type": "string",
+            "format": "fraction",
+            "description": "XResolution or YResolution value serialized as a string fraction 'numerator/denominator', meaning pixels per unit.",
+            "example": "96000/1000"
+        },
         {
             "name": "resolution_unit",
             "type": "integer",
-            "description": "Value of the TIFF ResolutionUnit tag (tag 296): 1 = No absolute unit (transform not applicable), 2 = Inch (25400000 nm/inch), 3 = Centimetre (10000000 nm/cm).",
-            "required": true
+            "format": "tiff-resolution-unit",
+            "description": "TIFF ResolutionUnit code: 1 = no absolute unit, 2 = inch, 3 = centimetre.",
+            "example": 2
         }
     ],
-    "notes": "Conversion constants: 1 inch = 25,400,000 nm; 1 cm = 10,000,000 nm. For ResolutionUnit=2 (inch): nm_per_px = 25400000 / resolution_float. For ResolutionUnit=3 (cm): nm_per_px = 10000000 / resolution_float. For ResolutionUnit=1 the transform must return an error or be skipped."
+    "output": {
+        "type": "number",
+        "unit": "nm/px",
+        "description": "Pixel size in nm/px.",
+        "example": 264583.33
+    },
+    "parameters": [],
+    "behavior": {
+        "onMissingInput": "error",
+        "onInvalidInput": "error",
+        "onUnknownValue": "error"
+    },
+    "examples": [
+        {
+            "description": "96 pixels per inch expressed as a TIFF rational string.",
+            "inputs": {
+                "resolution": "96000/1000",
+                "resolution_unit": 2
+            },
+            "output": 264583.33
+        }
+    ],
+    "notes": "Conversion constants: 1 inch = 25,400,000 nm; 1 cm = 10,000,000 nm. For ResolutionUnit=2 (inch): nm_per_px = 25400000 / resolution_float. For ResolutionUnit=3 (cm): nm_per_px = 10000000 / resolution_float. For ResolutionUnit=1 the transform is not applicable and should error or be skipped according to the consuming tool's policy."
 }

--- a/connectors/transforms/resolution-to-nm-per-px.json
+++ b/connectors/transforms/resolution-to-nm-per-px.json
@@ -1,0 +1,25 @@
+{
+    "$schema": "./transform-schema.json",
+    "id": "resolution-to-nm-per-px",
+    "name": "TIFF Resolution to nm/px",
+    "description": "Converts a TIFF XResolution or YResolution rational value (pixels per unit) combined with the ResolutionUnit tag into a pixel size in nanometres per pixel (nm/px) as expected by the FAMH Pixel Width/Pixel Height fields. The conversion is: nm_per_px = unit_in_nm / (resolution_in_pixels_per_unit). Important caveat: most SEM and FIB tools store calibrated pixel size in a vendor-specific TIFF tag and set ResolutionUnit=1 ('No absolute unit of measurement'), which makes this transform inapplicable. In those cases, use the vendor-specific connector instead.",
+    "input": {
+        "type": "rational",
+        "description": "XResolution or YResolution rational string as returned by `famdo extract` (e.g. '96000/1000', meaning 96 pixels per unit). The resolution unit is provided via the 'resolution_unit' parameter.",
+        "example": "96000/1000"
+    },
+    "output": {
+        "type": "number",
+        "description": "Pixel size in nm/px.",
+        "example": 264.58
+    },
+    "parameters": [
+        {
+            "name": "resolution_unit",
+            "type": "integer",
+            "description": "Value of the TIFF ResolutionUnit tag (tag 296): 1 = No absolute unit (transform not applicable), 2 = Inch (25400000 nm/inch), 3 = Centimetre (10000000 nm/cm).",
+            "required": true
+        }
+    ],
+    "notes": "Conversion constants: 1 inch = 25,400,000 nm; 1 cm = 10,000,000 nm. For ResolutionUnit=2 (inch): nm_per_px = 25400000 / resolution_float. For ResolutionUnit=3 (cm): nm_per_px = 10000000 / resolution_float. For ResolutionUnit=1 the transform must return an error or be skipped."
+}

--- a/connectors/transforms/transform-schema.json
+++ b/connectors/transforms/transform-schema.json
@@ -1,0 +1,135 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "transform-schema.json",
+    "title": "FA Metadata Header – Connector Transform Definition",
+    "description": "Defines the structure of a transform definition file. Transforms describe how a raw source value (e.g. a TIFF tag value) is converted into the form expected by the FAMH schema target field.",
+    "version": "1.0.0",
+    "type": "object",
+    "required": [
+        "id",
+        "name",
+        "description",
+        "input",
+        "output"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "$schema": {
+            "type": "string",
+            "description": "URI of the transform schema (transform-schema.json)"
+        },
+        "id": {
+            "type": "string",
+            "description": "Unique, stable identifier for this transform. Used to reference it in connector mappings via the 'transform' field.",
+            "pattern": "^[a-z][a-z0-9-]*$"
+        },
+        "name": {
+            "type": "string",
+            "description": "Human-readable transform name"
+        },
+        "description": {
+            "type": "string",
+            "description": "Detailed explanation of what the transform does, including any edge cases or limitations"
+        },
+        "input": {
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "description": "Describes the expected input to the transform",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "JSON Schema primitive type or 'rational' for TIFF rational values",
+                    "enum": [
+                        "string",
+                        "number",
+                        "integer",
+                        "boolean",
+                        "array",
+                        "object",
+                        "rational"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Human-readable description of the expected input format or constraints"
+                },
+                "example": {
+                    "description": "A representative example of a valid input value"
+                }
+            }
+        },
+        "output": {
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "description": "Describes what the transform produces",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "JSON Schema primitive type of the output",
+                    "enum": [
+                        "string",
+                        "number",
+                        "integer",
+                        "boolean",
+                        "array",
+                        "object"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Human-readable description of the output format"
+                },
+                "example": {
+                    "description": "A representative example of a valid output value"
+                }
+            }
+        },
+        "parameters": {
+            "type": "array",
+            "description": "Optional configurable parameters that modify the transform behaviour",
+            "items": {
+                "type": "object",
+                "required": [
+                    "name",
+                    "type",
+                    "description"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "string",
+                            "number",
+                            "integer",
+                            "boolean"
+                        ]
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "required": {
+                        "type": "boolean",
+                        "default": false
+                    },
+                    "default": {
+                        "description": "Default value used when the parameter is not specified"
+                    }
+                }
+            }
+        },
+        "notes": {
+            "type": "string",
+            "description": "Additional implementation notes, caveats, or references"
+        }
+    }
+}

--- a/connectors/transforms/transform-schema.json
+++ b/connectors/transforms/transform-schema.json
@@ -9,7 +9,7 @@
         "id",
         "name",
         "description",
-        "input",
+        "inputs",
         "output"
     ],
     "additionalProperties": false,
@@ -31,47 +31,98 @@
             "type": "string",
             "description": "Detailed explanation of what the transform does, including any edge cases or limitations"
         },
-        "input": {
+        "appliesTo": {
             "type": "object",
-            "required": [
-                "type"
-            ],
-            "description": "Describes the expected input to the transform",
+            "description": "Optional scope information that makes source-format-specific or target-convention-specific assumptions explicit.",
             "additionalProperties": false,
             "properties": {
-                "type": {
+                "sourceFormat": {
                     "type": "string",
-                    "description": "JSON Schema primitive type or 'rational' for TIFF rational values",
-                    "enum": [
-                        "string",
-                        "number",
-                        "integer",
-                        "boolean",
-                        "array",
-                        "object",
-                        "rational"
-                    ]
+                    "description": "Optional source metadata family or file format the transform assumes, for example \"TIFF\"."
                 },
-                "description": {
+                "targetConvention": {
                     "type": "string",
-                    "description": "Human-readable description of the expected input format or constraints"
-                },
-                "example": {
-                    "description": "A representative example of a valid input value"
+                    "description": "Optional target-side convention or schema expectation the transform is designed for, for example \"FAMH Color Mode\"."
                 }
             }
         },
+        "inputs": {
+            "type": "array",
+            "minItems": 1,
+            "description": "Ordered list of runtime inputs required by the transform. Use multiple entries when the conversion depends on more than one source value.",
+            "items": {
+                "$ref": "#/definitions/inputSpec"
+            }
+        },
         "output": {
+            "description": "Describes what the transform produces",
+            "$ref": "#/definitions/valueSpec"
+        },
+        "parameters": {
+            "type": "array",
+            "description": "Optional configurable parameters that modify the transform behaviour",
+            "items": {
+                "$ref": "#/definitions/parameterSpec"
+            }
+        },
+        "behavior": {
+            "type": "object",
+            "description": "Optional machine-readable handling rules for common edge cases.",
+            "additionalProperties": false,
+            "properties": {
+                "onMissingInput": {
+                    "type": "string",
+                    "enum": [
+                        "error",
+                        "skip",
+                        "null"
+                    ],
+                    "description": "What to do when one of the declared inputs is missing."
+                },
+                "onInvalidInput": {
+                    "type": "string",
+                    "enum": [
+                        "error",
+                        "skip",
+                        "null"
+                    ],
+                    "description": "What to do when the input exists but does not match the declared type or format."
+                },
+                "onUnknownValue": {
+                    "type": "string",
+                    "enum": [
+                        "error",
+                        "skip",
+                        "null",
+                        "passthrough",
+                        "string-fallback"
+                    ],
+                    "description": "What to do when the input is well-formed but not covered by a transform-specific lookup table or rule set."
+                }
+            }
+        },
+        "examples": {
+            "type": "array",
+            "description": "Optional worked examples that show how named inputs, parameters, and output fit together.",
+            "items": {
+                "$ref": "#/definitions/exampleSpec"
+            }
+        },
+        "notes": {
+            "type": "string",
+            "description": "Additional implementation notes, caveats, or references"
+        }
+    },
+    "definitions": {
+        "valueSpec": {
             "type": "object",
             "required": [
                 "type"
             ],
-            "description": "Describes what the transform produces",
-            "additionalProperties": false,
             "properties": {
                 "type": {
                     "type": "string",
-                    "description": "JSON Schema primitive type of the output",
+                    "description": "JSON Schema primitive type.",
                     "enum": [
                         "string",
                         "number",
@@ -81,55 +132,91 @@
                         "object"
                     ]
                 },
+                "format": {
+                    "type": "string",
+                    "description": "Optional format or encoding hint, for example \"fraction\", \"tiff-datetime\", or \"iso8601-date-time\"."
+                },
+                "unit": {
+                    "type": "string",
+                    "description": "Optional unit hint for numeric values, for example \"nm/px\"."
+                },
                 "description": {
                     "type": "string",
-                    "description": "Human-readable description of the output format"
+                    "description": "Human-readable description of the value shape or constraints."
                 },
                 "example": {
-                    "description": "A representative example of a valid output value"
+                    "description": "A representative example of a valid value."
                 }
             }
         },
-        "parameters": {
-            "type": "array",
-            "description": "Optional configurable parameters that modify the transform behaviour",
-            "items": {
-                "type": "object",
-                "required": [
-                    "name",
-                    "type",
-                    "description"
-                ],
-                "additionalProperties": false,
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "type": "string",
-                        "enum": [
-                            "string",
-                            "number",
-                            "integer",
-                            "boolean"
-                        ]
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "required": {
-                        "type": "boolean",
-                        "default": false
-                    },
-                    "default": {
-                        "description": "Default value used when the parameter is not specified"
+        "inputSpec": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/valueSpec"
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "name"
+                    ],
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Stable input name used in examples and in implementation bindings."
+                        }
                     }
                 }
-            }
+            ]
         },
-        "notes": {
-            "type": "string",
-            "description": "Additional implementation notes, caveats, or references"
+        "parameterSpec": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/valueSpec"
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "name",
+                        "description"
+                    ],
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "required": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "default": {
+                            "description": "Default value used when the parameter is not specified."
+                        }
+                    }
+                }
+            ]
+        },
+        "exampleSpec": {
+            "type": "object",
+            "required": [
+                "inputs",
+                "output"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "inputs": {
+                    "type": "object",
+                    "description": "Map of input names to example values for this transform invocation."
+                },
+                "parameters": {
+                    "type": "object",
+                    "description": "Optional map of parameter names to example values."
+                },
+                "output": {
+                    "description": "Expected output value for the example invocation."
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This PR adds the schema for defining FAMH connector files which allow mapping of file metadata to the FAMH format.

# Summary
This PR introduces a connector format for mapping extracted image metadata to the FAMH schema, with an initial TIFF-focused example and a small catalog of transform definitions.

# Changes
add a connector schema for source-to-target mappings
use numeric TIFF tag IDs as the canonical source identifier, while keeping tag names for readability
support structured transform invocations with primary inputs, additional named inputs, and optional parameters
add a standard TIFF mapping example covering direct mappings and transform-based mappings
add a transform schema plus initial transform definitions for:
TIFF DateTime to ISO 8601
TIFF resolution to nm/px
PhotometricInterpretation to FAMH Color Mode
generic fraction string to float
document the connector and transform format in the connectors README
add a workspace skill for generating connector files from [famdo extract](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) output, including sidecar [.unresolved.json](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) output for ambiguous mappings

## Validation
validated the standard TIFF connector against the connector schema
validated all transform definition files against the transform schema
checked multi-input bindings for the resolution transform ([ResolutionUnit](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) tag 296)

### Notes
This PR defines the connector contract, transform model, documentation, example mappings, and authoring workflow. It does not yet implement runtime execution of these transform invocations in consuming tools such as [famdo](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).